### PR TITLE
Fix inefficiency

### DIFF
--- a/Properties.lua
+++ b/Properties.lua
@@ -1,6 +1,10 @@
 --> Created all by loueque, thanks to RuizuKun_Dev for finding spelling mistakes and suggestions. :thumbs_up:
 --> Source of HTTP, credits to them with some modifications: https://scriptinghelpers.org/questions/50784/how-to-get-list-of-object-properties
 
+local HttpService = game:GetService("HttpService")
+local JSONLink = tostring("https://anaminus.github.io/rbx/json/api/latest.json")
+local HttpData = HttpService:JSONDecode(HttpService:GetAsync("https://anaminus.github.io/rbx/json/api/latest.json"))
+
 local Properties = {}
 Properties.__index = {}
 
@@ -12,9 +16,6 @@ end
 function Properties.GetProperties(instance: string | any)
 	local Property do
 		Property = {}
-		local HttpService = game:GetService("HttpService")
-		local JSONLink = tostring("https://anaminus.github.io/rbx/json/api/latest.json")
-		local HttpData = HttpService:JSONDecode(HttpService:GetAsync("https://anaminus.github.io/rbx/json/api/latest.json"))
 
 		for i = 1, #HttpData do
 			local Table = HttpData[i]
@@ -50,13 +51,6 @@ function Properties.GetProperties(instance: string | any)
 						table.insert(Class, Property)
 					end
 				end
-				
-			elseif Type == "Function" then
-			elseif Type == "YieldFunction" then
-			elseif Type == "Event" then
-			elseif Type == "Callback" then
-			elseif Type == "Enum" then
-			elseif Type == "EnumItem" then
 			end
 		end
 	end


### PR DESCRIPTION
Properties.GetProperties is very slow and inefficient because it calls HttpService:GetAsync everytime instead of once then using the cached results.