### PR TITLE
Add pcall / retrying and make requiring not yield

### DIFF
--- a/Properties.lua
+++ b/Properties.lua
@@ -1,18 +1,55 @@
 --> Created all by loueque, thanks to RuizuKun_Dev for finding spelling mistakes and suggestions. :thumbs_up:
 --> Source of HTTP, credits to them with some modifications: https://scriptinghelpers.org/questions/50784/how-to-get-list-of-object-properties
 
+local RunService = game:GetService("RunService")
 local HttpService = game:GetService("HttpService")
-local HttpData = HttpService:JSONDecode(HttpService:GetAsync("https://anaminus.github.io/rbx/json/api/latest.json"))
+local HttpData;
+
+coroutine.wrap(function()
+	local tries = 0
+	local sucess, data;
+	while true do
+		sucess, data = pcall(
+			HttpService.GetAsync,
+			HttpService,
+			"https://anaminus.github.io/rbx/json/api/latest.json"
+		)
+
+		if sucess then
+			HttpData = HttpService:JSONDecode(data)
+			break
+		end
+
+		tries += 1
+		if tries >= 3 then
+			warn("[Properties+ Http Error]: ", data)
+		end
+
+		wait(3)
+	end
+end)()
 
 local Properties = {}
 Properties.__index = {}
+
+local function WaitForHttpDataReady()
+	while HttpData == nil do
+		RunService.Heartbeat:Wait()
+	end
+end
 
 function Properties.new()
 	local new = {}
 	return setmetatable(new, Properties)
 end
 
+function Properties.WaitForDataLoaded()
+	WaitForHttpDataReady()
+end
+
 function Properties.GetProperties(instance: string | any)
+	WaitForHttpDataReady()
+
 	local Property do
 		Property = {}
 


### PR DESCRIPTION
This adds retrying and proper pcall, and makes it so that when you call `.GetProperties` it will yield until the data is loaded, if the data is not loaded yet.

Also this adds another function, `.WaitForDataLoaded()` which yields until the data is loaded.

